### PR TITLE
Fix an issue with the project metadata display

### DIFF
--- a/src/components/ProjectPreview/ProjectPreview.module.css
+++ b/src/components/ProjectPreview/ProjectPreview.module.css
@@ -18,7 +18,6 @@
 .projectMeta dt {
   grid-column-start: title;
   font-weight: 500;
-  color: white;
   margin: 0;
 }
 


### PR DESCRIPTION
The `dt` element was hard-coded to be in white, when it should have been inheriting the default text colour.